### PR TITLE
Fix bug that avoids loops when propagating announcements

### DIFF
--- a/bgpy/simulation_engine/policies/bgp/bgp_full/propagate_funcs.py
+++ b/bgpy/simulation_engine/policies/bgp/bgp_full/propagate_funcs.py
@@ -49,6 +49,9 @@ def _send_anns(self: "BGPFull", propagate_to: "Relationships"):
     neighbors: list[AS] = getattr(self.as_, propagate_to.name.lower())
 
     for neighbor, _prefix, ann in self.send_q.info(neighbors):
+        # Don't propagate to a neighbor that appears in the path to avoid loops
+        if neighbor.asn in ann.as_path:
+            continue
         neighbor.policy.receive_ann(ann)
         # Update Ribs out if it's not a withdraw
         if not ann.withdraw:


### PR DESCRIPTION
I identified a bug where ASes propagate BGP announcements to neighbors without validating if the AS already exists in the AS_PATH attribute. This oversight leads to a scenario where routing loops can occur, violating BGP’s loop prevention mechanism.

To resolve this issue, I implemented a check to ensure that an AS does not propagate announcements to neighbors if it already appears in the AS_PATH.