### PR TITLE
Fix bug in ASRA-B

### DIFF
--- a/bgpy/simulation_engine/policies/aspa/asra.py
+++ b/bgpy/simulation_engine/policies/aspa/asra.py
@@ -38,7 +38,7 @@ class ASRA(ASPA):
         # If from_rel == PROVIDER, do ASRA-B "fake link" checks
         # i.e., check from min_up_ramp up to the end of the path
 
-        path = ann.as_path
+        path = ann.as_path[::-1]
         n = len(path)
 
         # Compute min_up_ramp in a simple way:
@@ -70,7 +70,7 @@ class ASRA(ASPA):
 
         If we never fail, we return len(path).
         """
-        path = ann.as_path
+        path = ann.as_path[::-1]
         for i in range(len(path) - 1):
             asn1 = path[i]
             asn2 = path[i + 1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bgpy_pkg"
-version = "13.0.3"
+version = "13.0.4"
 requires-python = ">=3.10"
 description = "Simulates BGP, ROV, ASPA, etc in an extensible manner"
 readme = "README.md"

--- a/scripts/aspawn_debug.py
+++ b/scripts/aspawn_debug.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from bgpy.shared.enums import SpecialPercentAdoptions
-from bgpy.simulation_engine import ASRA
+from bgpy.simulation_engine import ASRA, ASPAwN
 from bgpy.simulation_framework import ScenarioConfig, Simulation, ForgedOriginPrefixHijack
 
 
@@ -22,6 +22,7 @@ def main():
         ),
         scenario_configs=(
             ScenarioConfig(ScenarioCls=ForgedOriginPrefixHijack, AdoptPolicyCls=ASRA),
+            ScenarioConfig(ScenarioCls=ForgedOriginPrefixHijack, AdoptPolicyCls=ASPAwN),
         ),
         output_dir=Path("~/Desktop/aspawn").expanduser(),
         num_trials=10,


### PR DESCRIPTION
In the ASRA Internet Draft, the origin is treated as the low index (1) in the AS path, but in BGPy, the low index is the most-recently added AS. This reverses the AS path so the algorithm runs correctly. 